### PR TITLE
Added config.vm.box_url to Vagrantfile to auto download box since it is ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ or one of the Github GUI clients: [OSX](http://mac.github.com/), [Windows] (http
 1. Assuming you have met the above requirements. 
 2. Provision a new Vagrant VM (using PythonDevBootstrapPrecise as example)
 
-        $ vagrant box add PythonDevBootstrapPrecise http://files.vagrantup.com/precise32.box
         $ cd python-dev-bootstrap (Wherever your cloned path is for this repo)
         $ vagrant up
  		$ vagrant ssh

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,7 @@
 Vagrant::Config.run do |config|
   
   config.vm.box = "PythonDevBootstrapPrecise"
+  config.vm.box_url = "http://files.vagrantup.com/precise32.box"
   config.ssh.guest_port = 22
   config.vm.customize ["modifyvm", :id, "--memory", 512]
 


### PR DESCRIPTION
...unlikely that a user has a box named 'PythonDevBootstrapPrecise' already
